### PR TITLE
Unify intervals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "parser": "babel-eslint",
   "extends": ["standard", "standard-react"],
   "env": {
-    "jest": true
+    "jest": true,
+    "browser": true
   },
   "rules": {
     "no-redeclare": 0

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint-staged"
   ],
   "jest": {
+    "browser": true,
     "collectCoverageFrom": [
       "src/**/*.js",
       "!src/docs/*"

--- a/src/AbstractCounterDigit.js
+++ b/src/AbstractCounterDigit.js
@@ -2,11 +2,10 @@ import React from 'react'
 const { objectOf, any, number, string, func } = React.PropTypes
 
 /**
- * common logic for {@link StaticCounterDigit} and {@link AnimatedCounterDigit}
+ * Common logic for {@link StaticCounterDigit} and {@link AnimatedCounterDigit}.
  */
 class AbstractCounterDigit extends React.Component {
   /**
-   * propTypes
    * @property {string} digit - digit to display
    * @property {number} height - digit height in pixels
    * @property {number} radix
@@ -22,7 +21,7 @@ class AbstractCounterDigit extends React.Component {
   }
 
   /**
-   * decorates given digit according to radix, digit map and digit wrapper
+   * Decorates given digit according to radix, digit map and digit wrapper.
    * @param {number} digit
    * @return {string} decoratedDigit
    */

--- a/src/AnimatedCounterDigit.js
+++ b/src/AnimatedCounterDigit.js
@@ -4,7 +4,7 @@ import AbstractCounterDigit from './AbstractCounterDigit'
 const { number, string } = React.PropTypes
 
 /**
- * forces reflow of a given element
+ * Forces reflow of a given element.
  * @param {Element} element
  */
 function forceReflow (element) {
@@ -12,8 +12,8 @@ function forceReflow (element) {
 }
 
 /**
- * animated digit component
- * used when easing function is provided
+ * Animated digit component.
+ * Used when counter has an easing function.
  * @example
  * <AnimatedCounterDigit
  *   digit='5'
@@ -28,7 +28,6 @@ function forceReflow (element) {
  */
 class AnimatedCounterDigit extends AbstractCounterDigit {
   /**
-   * propTypes
    * @property {number} maxValue - maximum value used to build a digit lane
    * @property {string} easingFunction - easing function for transitions
    * @property {number} easingDuration - duration for digit transitions in milliseconds
@@ -40,17 +39,13 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
     easingDuration: number.isRequired
   }
 
-  /**
-   * componentDidMount
-   * calls reset in case current digit is a zero
-   */
   componentDidMount () {
     this.reset({ target: ReactDOM.findDOMNode(this) })
   }
 
   /**
-   * changes vertical position of digit lane without triggering a transition
-   * in a lane like [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0] goes from first zero to last zero instantly
+   * Changes vertical position of digit lane without triggering a transition.
+   * In a lane like [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0] goes from first zero to last zero instantly.
    * @param {SyntheticEvent} event
    */
   reset = (event) => {
@@ -63,7 +58,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   }
 
   /**
-   * creates a div for a digit lane member
+   * Creates a div for a digit lane member.
    * @param {string} digit
    * @param {number} key - index to use for React's key property
    * @return {ReactElement}
@@ -77,9 +72,9 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   }
 
   /**
-   * builds the digit lane
-   * digit lane contains all available digits
-   * it changes its vertical position in order to emulate counter rolling
+   * Builds the digit lane.
+   * Digit lane contains all available digits.
+   * It changes its vertical position in order to emulate counter rolling.
    * @return {ReactElement[]}
    */
   buildDigitLane () {
@@ -92,7 +87,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   }
 
   /**
-   * render
+   * Renders the digit.
    * @return {ReactElement} digit
    */
   render () {

--- a/src/CounterSegment.js
+++ b/src/CounterSegment.js
@@ -6,7 +6,7 @@ const { arrayOf, objectOf, number, string, any, func } = React.PropTypes
 
 /**
  * @type {Object}
- * maximum decimal values for available periods' numbers
+ * Maximum decimal values for available periods' numbers.
  */
 const PERIOD_LIMITS = {
   'seconds': 59,
@@ -16,7 +16,7 @@ const PERIOD_LIMITS = {
 }
 
 /**
- * counter segment component
+ * Counter segment component.
  * @example
  * <CounterSegment
  *   digits={['0', '0']}
@@ -29,7 +29,6 @@ const PERIOD_LIMITS = {
  */
 class CounterSegment extends React.Component {
   /**
-   * propTypes
    * @property {string[]} digits - digits to display
    * @property {string} period
    * @property {number} radix
@@ -50,12 +49,14 @@ class CounterSegment extends React.Component {
 
   /**
    * constructor
-   * calculates height of a single digit
    * @param {Object} props
    */
   constructor (props) {
     super(props)
 
+    /**
+     * Calculates height of a single digit.
+     */
     const testDigit = document.createElement('div')
     testDigit.innerHTML = ReactDOMServer.renderToString(this.props.digitWrapper('0'))
     document.getElementsByTagName('body')[0].appendChild(testDigit)
@@ -71,8 +72,8 @@ class CounterSegment extends React.Component {
   }
 
   /**
-   * get maximum value for period's digit with account for radix
-   * used for building digit lanes in {@link AnimatedCounterDigit}
+   * Gets maximum value for period's digit with account for radix.
+   * Used for building digit lanes in {@link AnimatedCounterDigit}.
    * @param {number} index - digit's index in number
    * @return {number} maxValue
    */
@@ -88,7 +89,7 @@ class CounterSegment extends React.Component {
   }
 
   /**
-   * map digits to corresponding components according to easing function
+   * Maps digits to corresponding components according to easing function.
    * @return {ReactElement[]}
    */
   buildDigits () {
@@ -123,7 +124,7 @@ class CounterSegment extends React.Component {
   }
 
   /**
-   * render
+   * Renders the segment.
    * @return {ReactElement} counter segment
    */
   render () {

--- a/src/StaticCounterDigit.js
+++ b/src/StaticCounterDigit.js
@@ -2,8 +2,8 @@ import React from 'react'
 import AbstractCounterDigit from './AbstractCounterDigit'
 
 /**
- * static digit component
- * used when no easing function is set
+ * Static digit component.
+ * Used when no easing function is set for a counter.
  * @example
  * <StaticCounterDigit
  *   digit='5'
@@ -15,7 +15,7 @@ import AbstractCounterDigit from './AbstractCounterDigit'
  */
 class StaticCounterDigit extends AbstractCounterDigit {
   /**
-   * render
+   * Renders the digit.
    * @return {ReactElement} digit
    */
   render () {

--- a/src/globalIntervals.js
+++ b/src/globalIntervals.js
@@ -1,0 +1,50 @@
+/**
+ * Helper object with global interval management functions.
+ */
+const GlobalIntervals = {
+  /**
+   * Ensures existence of an interval.
+   * @param {!number} duration - interval duration in milliseconds
+   */
+  ensureExistence (duration) {
+    if (!window.rollexIntervals) window.rollexIntervals = {}
+    if (!window.rollexIntervals[duration]) {
+      window.rollexIntervals[duration] = {
+        interval: setInterval(() => {
+          window.dispatchEvent(new CustomEvent(`rollex:tick:${duration}`))
+        }, duration, false),
+        counterCount: 0
+      }
+    }
+  },
+  /**
+   * Cleans up an interval.
+   * @param {!number} duration - interval duration in milliseconds
+   */
+  cleanup (duration) {
+    if (window.rollexIntervals[duration].counterCount === 0) {
+      clearInterval(window.rollexIntervals[duration].interval)
+      delete (window.rollexIntervals[duration])
+    }
+  },
+  /**
+   * Adds a subscriber to an interval.
+   * @param {!number} duration - interval duration in milliseconds
+   * @param {!Object|function} subscriber
+   */
+  subscribe (duration, subscriber) {
+    window.rollexIntervals[duration].counterCount += 1
+    window.addEventListener(`rollex:tick:${duration}`, subscriber, false)
+  },
+  /**
+   * Removes a subscriber from an interval.
+   * @param {!number} duration - interval duration in milliseconds
+   * @param {!Object|function} subscriber
+   */
+  unsubscribe (duration, subscriber) {
+    window.removeEventListener(`rollex:tick:${duration}`, subscriber, false)
+    window.rollexIntervals[duration].counterCount -= 1
+  }
+}
+
+export default GlobalIntervals

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import CounterSegment from './CounterSegment'
+import GlobalIntervals from './globalIntervals'
 const { number, string, bool, objectOf, any, func } = React.PropTypes
 
 /**
  * @type {string[]}
- * names for available periods
+ * Names for available periods.
  */
 const PERIODS = [
   'days',
@@ -15,7 +16,7 @@ const PERIODS = [
 
 /**
  * @type {Object}
- * durations for available periods (in milliseconds)
+ * Durations for available periods (in milliseconds).
  */
 const PERIOD_DURATIONS = {
   'days': 86400000,
@@ -26,7 +27,7 @@ const PERIOD_DURATIONS = {
 
 /**
  * @type {Object}
- * time calculation functions for available periods
+ * Time calculation functions for available periods.
  */
 const PERIOD_DURATION_FUNCTIONS = {
   'hours': 'getUTCHours',
@@ -35,13 +36,12 @@ const PERIOD_DURATION_FUNCTIONS = {
 }
 
 /**
- * main counter component
+ * Main counter component.
  * @example
  * <Counter seconds={98} />
  */
 export default class Counter extends React.Component {
   /**
-   * propTypes
    * @property {number} from - timestamp to count from
    * @property {number} to - timestamp to count to
    * @property {number} seconds - a number of seconds to count
@@ -118,6 +118,12 @@ export default class Counter extends React.Component {
       periods: this.getPeriods()
     }
     this.state.numbers = this.calculateNumbers(timeDiff)
+
+    /**
+     * Creates a function bound to "this"
+     * for subscribing to and unsubscribing from global Rollex tick event.
+     */
+    this.boundTick = this.tick.bind(this)
   }
 
   componentDidMount () {
@@ -128,6 +134,10 @@ export default class Counter extends React.Component {
     if (!this.props.frozen) this.stop()
   }
 
+  /**
+   * Handles prop updates.
+   * @param {Object} nextProps - new props
+   */
   componentWillReceiveProps (nextProps) {
     if (this.props.frozen !== nextProps.frozen) {
       if (nextProps.frozen) {
@@ -139,21 +149,23 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * start the countdown
+   * Starts the countdown.
    */
   start () {
-    this._interval = setInterval(() => this.tick(), this.props.interval)
+    GlobalIntervals.ensureExistence(this.props.interval)
+    GlobalIntervals.subscribe(this.props.interval, this.boundTick)
   }
 
   /**
-   * pause / stop the countdown
+   * Pauses the countdown.
    */
   stop () {
-    clearInterval(this._interval)
+    GlobalIntervals.unsubscribe(this.props.interval, this.boundTick)
+    GlobalIntervals.cleanup(this.props.interval)
   }
 
   /**
-   * handle counter tick
+   * Handles counter ticks.
    */
   tick () {
     const newTimeDiff = this.getTimeDiff()
@@ -173,7 +185,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * calculates minimum number of digits for current radix
+   * Calculates minimum number of digits for current radix.
    * @return {number}
    */
   getInitialMinDigits () {
@@ -181,7 +193,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * get current amount of time to count from
+   * Gets current amount of time to count from.
    * @return {number} timestamp
    */
   getTimeDiff () {
@@ -193,7 +205,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * get an array of periods to create segments for
+   * Gets an array of periods to create segments for.
    * @return {string[]} periods
    */
   getPeriods () {
@@ -204,7 +216,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * get CSS classes for main counter
+   * Gets CSS classes for main counter.
    * @return {string} class names
    */
   getCSSClassNames () {
@@ -213,7 +225,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * calculate numbers for each period for a given timestamp
+   * Calculates numbers for each period for a given timestamp.
    * @param {number} timeDiff - timestamp to calculate numbers for
    * @return {Object} numbers - a map from periods to corresponding numbers
    */
@@ -226,7 +238,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * calculate number for given period and timestamp
+   * Calculates number for given period and timestamp.
    * @param {string} period - period to calculate number for
    * @param {number} timeDiff - timestamp to use for calculation
    * @return {number}
@@ -241,7 +253,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * get correct digits for given number accounting for counter's radix, minDigits and maxDigits
+   * Gets correct digits for given number accounting for counter's radix, minDigits and maxDigits.
    * @param {number} number - number to get digits for
    * @return {string[]} digits
    */
@@ -262,7 +274,7 @@ export default class Counter extends React.Component {
   }
 
   /**
-   * render
+   * Renders the counter.
    * @return {ReactElement} counter
    */
   render () {
@@ -288,7 +300,7 @@ export default class Counter extends React.Component {
 }
 
 /**
- * validate counter's props
+ * Validates counter's props.
  * @param {Object} props - props to validate
  */
 function validateProps (props) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -277,23 +277,23 @@ describe('state and props', function () {
 })
 
 describe('counting', function () {
-  var component
-
   beforeEach(function () {
+    jest.clearAllTimers()
     jest.useFakeTimers()
-    component = mount(<Counter from={0} to={10000} />)
-    expect(component.state().numbers.seconds).toBe(10)
-    expect(setInterval.mock.calls.length).toBe(1)
+    delete (window.rollexIntervals)
+    // FIXME: the following line is required. It shouldn't be. Something's wrong with global state.
+    mount(<Counter seconds={10000} />)
   })
 
   it('starts to count when mounted', function () {
+    const component = mount(<Counter from={0} to={10000} />)
     jest.runTimersToTime(5000)
     expect(component.state().timeDiff).toBe(5000)
     expect(component.state().numbers.seconds).toBe(5)
   })
 
   it('works with "seconds" prop', function () {
-    component = mount(<Counter seconds={10} />)
+    const component = mount(<Counter seconds={10} />)
     expect(component.state().numbers.seconds).toBe(10)
     jest.runTimersToTime(5000)
     expect(component.state().timeDiff).toBe(5000)
@@ -301,13 +301,14 @@ describe('counting', function () {
   })
 
   it('does not count when "frozen" is true', function () {
-    component = mount(<Counter seconds={10} frozen />)
+    const component = mount(<Counter seconds={10} frozen />)
     jest.runTimersToTime(5000)
     expect(component.state().timeDiff).toBe(10000)
     expect(component.state().numbers.seconds).toBe(10)
   })
 
   it('stops to count when stopped', function () {
+    const component = mount(<Counter from={0} to={10000} />)
     jest.runTimersToTime(5000)
     expect(component.state().numbers.seconds).toBe(5)
 
@@ -318,6 +319,7 @@ describe('counting', function () {
   })
 
   it('stops to count when reached zero', function () {
+    const component = mount(<Counter from={0} to={10000} />)
     jest.runTimersToTime(10000)
     expect(component.state().timeDiff).toBe(0)
     expect(component.state().numbers.seconds).toBe(0)
@@ -328,7 +330,7 @@ describe('counting', function () {
   })
 
   it('stops to count if frozen prop is updated to true', function () {
-    component = mount(<Counter from={0} to={10000} />)
+    const component = mount(<Counter from={0} to={10000} />)
     component.instance().stop = jest.genMockFunction()
     component.instance().forceUpdate()
     component.setProps({
@@ -344,7 +346,7 @@ describe('counting', function () {
   })
 
   it('starts to count if frozen prop is updated to false', function () {
-    component = mount(<Counter from={0} to={10000} />)
+    const component = mount(<Counter from={0} to={10000} />)
     component.instance().start = jest.genMockFunction()
     component.instance().forceUpdate()
     component.setProps({
@@ -360,7 +362,7 @@ describe('counting', function () {
   })
 
   it('syncs time when syncTime is set', function () {
-    component = mount(<Counter from={0} to={10000} syncTime />)
+    const component = mount(<Counter from={0} to={10000} syncTime />)
     const newDate = component.state().currentTime + 7000
     jest.spyOn(Date.prototype, 'getTime').mockImplementation(() => newDate)
     jest.runTimersToTime(5000)


### PR DESCRIPTION
Only one `setInterval` is now called for the whole page as long as all the counters have the same `interval` property. In other words, only one `setInterval` is called for *each distinct counter interval*.