### PR TITLE
Add a way to provide custom labels

### DIFF
--- a/src/CounterSegment.js
+++ b/src/CounterSegment.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import AnimatedCounterDigit from './AnimatedCounterDigit'
 import StaticCounterDigit from './StaticCounterDigit'
-const { arrayOf, objectOf, number, string, any, func } = React.PropTypes
+const { arrayOf, object, number, string, func } = React.PropTypes
 
 /**
  * @type {Object}
@@ -38,6 +38,7 @@ class CounterSegment extends React.Component {
    * @property {number} easingDuration - duration of digit transitions
    * @property {Object} digitMap - a map for transforming particular digits
    * @property {function(digit: number)} digitWrapper - a function for wrapping mapped digits
+   * @property {string} label
    */
   static propTypes = {
     digits: arrayOf(string).isRequired,
@@ -46,8 +47,9 @@ class CounterSegment extends React.Component {
     direction: string.isRequired,
     easingFunction: string,
     easingDuration: number.isRequired,
-    digitMap: objectOf(any).isRequired,
-    digitWrapper: func.isRequired
+    digitMap: object.isRequired,
+    digitWrapper: func.isRequired,
+    label: string.isRequired
   }
 
   /**
@@ -142,7 +144,7 @@ class CounterSegment extends React.Component {
           {this.buildDigits()}
         </div>
         <div className='rollex-label'>
-          {this.props.period}
+          {this.props.label}
         </div>
       </div>
     )

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`rendering matches snapshot 1`] = `
     direction="down"
     easingDuration={300}
     easingFunction={null}
+    label="days"
     period="days"
     radix={10}
   />
@@ -31,6 +32,7 @@ exports[`rendering matches snapshot 1`] = `
     direction="down"
     easingDuration={300}
     easingFunction={null}
+    label="hours"
     period="hours"
     radix={10}
   />
@@ -46,6 +48,7 @@ exports[`rendering matches snapshot 1`] = `
     direction="down"
     easingDuration={300}
     easingFunction={null}
+    label="minutes"
     period="minutes"
     radix={10}
   />
@@ -61,6 +64,7 @@ exports[`rendering matches snapshot 1`] = `
     direction="down"
     easingDuration={300}
     easingFunction={null}
+    label="seconds"
     period="seconds"
     radix={10}
   />

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,12 +4,11 @@ import { shallowToJson } from 'enzyme-to-json'
 import Counter from '../src/'
 import CounterSegment from '../src/CounterSegment'
 
-beforeAll(function () {
-  console.error = jest.fn(() => null) // disable React PropTypes warnings
-})
-
 describe('initialization', function () {
   it('throws an error when options are provided incorrectly', function () {
+    const _error = console.error
+    console.error = jest.fn(() => null) // disable React PropTypes warnings
+
     expect(
       () => shallow(<Counter />)
     ).toThrowError('provide either "seconds" or "to"')
@@ -52,6 +51,8 @@ describe('initialization', function () {
     expect(
       () => shallow(<Counter to={0} direction='sobaka' />)
     ).toThrowError('"direction" must be either up or down')
+
+    console.error = _error
   })
 
   it('initializes when options are correct', function () {
@@ -221,6 +222,42 @@ describe('rendering', function () {
     expect(counterSegments.at(1).props().digitMap).toEqual(digitMap)
     expect(counterSegments.at(2).props().digitMap).toEqual(digitMap)
     expect(counterSegments.at(3).props().digitMap).toEqual(digitMap)
+  })
+
+  it('passes correct labels to segments', function () {
+    const component = shallow(<Counter to={1} />)
+    const counterSegments = component.find(CounterSegment)
+    expect(counterSegments.at(0).props().label).toEqual('days')
+    expect(counterSegments.at(1).props().label).toEqual('hours')
+    expect(counterSegments.at(2).props().label).toEqual('minutes')
+    expect(counterSegments.at(3).props().label).toEqual('seconds')
+
+    const labelMap = {
+      days: 'DD',
+      hours: 'HH',
+      minutes: 'MM',
+      seconds: 'SS'
+    }
+    const labelMapComponent = shallow(<Counter to={1} labels={labelMap} />)
+    const labelMapCounterSegments = labelMapComponent.find(CounterSegment)
+    expect(labelMapCounterSegments.at(0).props().label).toEqual('DD')
+    expect(labelMapCounterSegments.at(1).props().label).toEqual('HH')
+    expect(labelMapCounterSegments.at(2).props().label).toEqual('MM')
+    expect(labelMapCounterSegments.at(3).props().label).toEqual('SS')
+
+    const labelFunc = function (period, number) {
+      if (number % 10 === 1) {
+        return period.slice(0, -1)
+      } else {
+        return period
+      }
+    }
+    const labelFuncComponent = shallow(<Counter seconds={61} labels={labelFunc} />)
+    const labelFuncCounterSegments = labelFuncComponent.find(CounterSegment)
+    expect(labelFuncCounterSegments.at(0).props().label).toEqual('days')
+    expect(labelFuncCounterSegments.at(1).props().label).toEqual('hours')
+    expect(labelFuncCounterSegments.at(2).props().label).toEqual('minute')
+    expect(labelFuncCounterSegments.at(3).props().label).toEqual('second')
   })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,7 @@ import CounterSegment from '../src/CounterSegment'
 
 describe('initialization', function () {
   it('throws an error when options are provided incorrectly', function () {
-    const _error = console.error
+    const error = console.error
     console.error = jest.fn(() => null) // disable React PropTypes warnings
 
     expect(
@@ -52,7 +52,7 @@ describe('initialization', function () {
       () => shallow(<Counter to={0} direction='sobaka' />)
     ).toThrowError('"direction" must be either up or down')
 
-    console.error = _error
+    console.error = error
   })
 
   it('initializes when options are correct', function () {
@@ -224,40 +224,46 @@ describe('rendering', function () {
     expect(counterSegments.at(3).props().digitMap).toEqual(digitMap)
   })
 
-  it('passes correct labels to segments', function () {
-    const component = shallow(<Counter to={1} />)
-    const counterSegments = component.find(CounterSegment)
-    expect(counterSegments.at(0).props().label).toEqual('days')
-    expect(counterSegments.at(1).props().label).toEqual('hours')
-    expect(counterSegments.at(2).props().label).toEqual('minutes')
-    expect(counterSegments.at(3).props().label).toEqual('seconds')
+  describe('segment labels', function () {
+    it('passes default labels', function () {
+      const component = shallow(<Counter to={1} />)
+      const counterSegments = component.find(CounterSegment)
+      expect(counterSegments.at(0).props().label).toEqual('days')
+      expect(counterSegments.at(1).props().label).toEqual('hours')
+      expect(counterSegments.at(2).props().label).toEqual('minutes')
+      expect(counterSegments.at(3).props().label).toEqual('seconds')
+    })
 
-    const labelMap = {
-      days: 'DD',
-      hours: 'HH',
-      minutes: 'MM',
-      seconds: 'SS'
-    }
-    const labelMapComponent = shallow(<Counter to={1} labels={labelMap} />)
-    const labelMapCounterSegments = labelMapComponent.find(CounterSegment)
-    expect(labelMapCounterSegments.at(0).props().label).toEqual('DD')
-    expect(labelMapCounterSegments.at(1).props().label).toEqual('HH')
-    expect(labelMapCounterSegments.at(2).props().label).toEqual('MM')
-    expect(labelMapCounterSegments.at(3).props().label).toEqual('SS')
-
-    const labelFunc = function (period, number) {
-      if (number % 10 === 1) {
-        return period.slice(0, -1)
-      } else {
-        return period
+    it('passes labels when given a map', function () {
+      const labelMap = {
+        days: 'DD',
+        hours: 'HH',
+        minutes: 'MM',
+        seconds: 'SS'
       }
-    }
-    const labelFuncComponent = shallow(<Counter seconds={61} labels={labelFunc} />)
-    const labelFuncCounterSegments = labelFuncComponent.find(CounterSegment)
-    expect(labelFuncCounterSegments.at(0).props().label).toEqual('days')
-    expect(labelFuncCounterSegments.at(1).props().label).toEqual('hours')
-    expect(labelFuncCounterSegments.at(2).props().label).toEqual('minute')
-    expect(labelFuncCounterSegments.at(3).props().label).toEqual('second')
+      const component = shallow(<Counter to={1} labels={labelMap} />)
+      const segments = component.find(CounterSegment)
+      expect(segments.at(0).props().label).toEqual('DD')
+      expect(segments.at(1).props().label).toEqual('HH')
+      expect(segments.at(2).props().label).toEqual('MM')
+      expect(segments.at(3).props().label).toEqual('SS')
+    })
+
+    it('passes labels when given a function', function () {
+      const labelFunc = function (period, number) {
+        if (number % 10 === 1) {
+          return period.slice(0, -1)
+        } else {
+          return period
+        }
+      }
+      const component = shallow(<Counter seconds={61} labels={labelFunc} />)
+      const segments = component.find(CounterSegment)
+      expect(segments.at(0).props().label).toEqual('days')
+      expect(segments.at(1).props().label).toEqual('hours')
+      expect(segments.at(2).props().label).toEqual('minute')
+      expect(segments.at(3).props().label).toEqual('second')
+    })
   })
 })
 

--- a/test/support/builders.js
+++ b/test/support/builders.js
@@ -23,11 +23,12 @@ export class CounterSegmentBuilder extends AbstractBuilder {
     easingFunction = null,
     easingDuration = 300,
     digitMap = {},
-    digitWrapper = (digit) => <span>{digit}</span>
+    digitWrapper = (digit) => <span>{digit}</span>,
+    label = 'seconds'
   } = {}) {
     return React.createElement(
       CounterSegment,
-      { digits, period, radix, direction, easingFunction, easingDuration, digitMap, digitWrapper }
+      { digits, period, radix, direction, easingFunction, easingDuration, digitMap, digitWrapper, label }
     )
   }
 }


### PR DESCRIPTION
Default segment labels are the same as period names ("days", "hours", etc). This PR adds a way to provide custom labels via a map or a function. Examples:
```jsx
// map
<Counter
  seconds={90} 
  labels={{ days: 'DD', hours: 'HH', minutes: 'MM', seconds: 'SS' }} 
/>

// function
function labels (period, number) {
  // simple pluralisation: if the number ends with 1, label is singular;
  // otherwise it's plural.
  if (number % 10 === 1) {
    return period.slice(0, -1)
  } else {
    return period
  }
}
```