### PR TITLE
Add segment separators

### DIFF
--- a/src/CounterSegmentSeparator.js
+++ b/src/CounterSegmentSeparator.js
@@ -1,0 +1,31 @@
+import React from 'react'
+const { any } = React.PropTypes
+
+/**
+ * Separator between {@link CounterSegment} elements.
+ * @example
+ * <CounterSegmentSeparator content=':' />
+ */
+class CounterSegmentSeparator extends React.Component {
+  /**
+   * @property content
+   */
+  static propTypes = {
+    content: any
+  }
+
+  /**
+   * Renders the separator.
+   * @return {ReactElement} separator
+   */
+  render () {
+    if (this.props.content === undefined) return null
+    return (
+      <div className='rollex-separator'>
+        {this.props.content}
+      </div>
+    )
+  }
+}
+
+export default CounterSegmentSeparator

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import CounterSegment from './CounterSegment'
+import CounterSegmentSeparator from './CounterSegmentSeparator'
 import GlobalIntervals from './globalIntervals'
-const { number, string, bool, objectOf, object, oneOfType, oneOf, func } = React.PropTypes
+const { number, string, bool, objectOf, object, oneOfType, oneOf, func, any } = React.PropTypes
 
 /**
  * @type {string[]}
@@ -61,6 +62,7 @@ export default class Counter extends React.Component {
    * @property {function(digit: number)} digitWrapper - a wrapping function for mapped digits
    * @property {Map<string, string>|function(period: string, number: number)} labels - a map or a
    * function that returns labels for given period and number
+   * @property separator - what to separate segments with
    */
   static propTypes = {
     from: number,
@@ -79,7 +81,8 @@ export default class Counter extends React.Component {
     radix: number,
     digitMap: object,
     digitWrapper: func,
-    labels: oneOfType([objectOf(string), func])
+    labels: oneOfType([objectOf(string), func]),
+    separator: any
   }
 
   static defaultProps = {
@@ -315,18 +318,23 @@ export default class Counter extends React.Component {
   render () {
     const numbers = this.state.numbers
     const segments = this.state.periods.map((period, index) => {
-      return (<CounterSegment
-        period={period}
-        key={index}
-        digits={this.getDigits(numbers[period])}
-        radix={this.props.radix}
-        direction={this.props.direction}
-        easingFunction={this.props.easingFunction}
-        easingDuration={this.props.easingDuration}
-        digitMap={this.props.digitMap}
-        digitWrapper={this.props.digitWrapper}
-        label={this.getLabel(period, numbers[period])}
-      />)
+      const separator = index < this.state.periods.length - 1
+        ? <CounterSegmentSeparator content={this.props.separator} />
+        : null
+      return (<div key={index}>
+        <CounterSegment
+          period={period}
+          digits={this.getDigits(numbers[period])}
+          radix={this.props.radix}
+          direction={this.props.direction}
+          easingFunction={this.props.easingFunction}
+          easingDuration={this.props.easingDuration}
+          digitMap={this.props.digitMap}
+          digitWrapper={this.props.digitWrapper}
+          label={this.getLabel(period, numbers[period])}
+        />
+        {separator}
+      </div>)
     })
     return (
       <div className={this.state.cssClasses}>

--- a/test/acceptance/common.test.js
+++ b/test/acceptance/common.test.js
@@ -56,3 +56,23 @@ describe('custom labels', function () {
     expect(component).toHaveLabels(['DAYS', 'HOURS', 'MINUTES', 'SECONDS'])
   })
 })
+
+describe('separators', function () {
+  it('works with jsx', function () {
+    const separator = <a href='#'>l0l</a>
+    const component = render(<Counter seconds={10} separator={separator} />)
+    expect(component).toHaveSeparators(['l0l', 'l0l', 'l0l'])
+  })
+
+  it('works with numbers', function () {
+    const separator = 420
+    const component = render(<Counter seconds={10} separator={separator} />)
+    expect(component).toHaveSeparators(['420', '420', '420'])
+  })
+
+  it('works with strings', function () {
+    const separator = 'ur mum'
+    const component = render(<Counter seconds={10} separator={separator} />)
+    expect(component).toHaveSeparators(['ur mum', 'ur mum', 'ur mum'])
+  })
+})

--- a/test/acceptance/support/matchers.js
+++ b/test/acceptance/support/matchers.js
@@ -2,10 +2,7 @@ export default {
   toDisplayDigits (util, customEqualityTesters) {
     return {
       compare (object, expected) {
-        const actual = Array.prototype.slice.call(object.querySelectorAll('span'))
-          .filter((el) => isVisible(el))
-          .map((el) => el.textContent)
-          .join('')
+        const actual = getChildrenTextContents(object, 'span', true).join('')
         const pass = util.equals(actual, expected, customEqualityTesters)
 
         if (pass) {
@@ -21,8 +18,7 @@ export default {
   toHaveLabels (util, customEqualityTesters) {
     return {
       compare (object, expected) {
-        const actual = Array.prototype.slice.call(object.querySelectorAll('.rollex-label'))
-          .map((el) => el.textContent)
+        const actual = getChildrenTextContents(object, '.rollex-label')
         const pass = util.equals(actual, expected, customEqualityTesters)
 
         if (pass) {
@@ -34,7 +30,36 @@ export default {
         return { pass, message }
       }
     }
+  },
+  toHaveSeparators (util, customEqualityTesters) {
+    return {
+      compare (object, expected) {
+        const actual = getChildrenTextContents(object, '.rollex-separator')
+        const pass = util.equals(actual, expected, customEqualityTesters)
+
+        if (pass) {
+          var message = `Expected ${object} not to have separators: ${expected}`
+        } else {
+          var message = `Expected ${object} to have separators: ${expected}, but got: ${actual}`
+        }
+
+        return { pass, message }
+      }
+    }
   }
+}
+
+/**
+ * Gets text contents of children with given selector.
+ * @param {!Element} object
+ * @param {!string} selector
+ * @param {?boolean} onlyVisible - if true, will only return text contents of children that are visible
+ * @return {string[]} text contents
+ */
+function getChildrenTextContents (object, selector, onlyVisible = false) {
+  var children = Array.prototype.slice.call(object.querySelectorAll(selector))
+  if (onlyVisible) children = children.filter((el) => isVisible(el))
+  return children.map((el) => el.textContent)
 }
 
 /**

--- a/test/unit/__snapshots__/index.test.js.snap
+++ b/test/unit/__snapshots__/index.test.js.snap
@@ -4,69 +4,80 @@ exports[`rendering matches snapshot 1`] = `
 <div
   className="rollex rollex-static"
 >
-  <CounterSegment
-    digitMap={Object {}}
-    digitWrapper={[Function]}
-    digits={
-      Array [
-        "0",
-        "0",
-      ]
-    }
-    direction="down"
-    easingDuration={300}
-    easingFunction={null}
-    label="days"
-    period="days"
-    radix={10}
-  />
-  <CounterSegment
-    digitMap={Object {}}
-    digitWrapper={[Function]}
-    digits={
-      Array [
-        "0",
-        "0",
-      ]
-    }
-    direction="down"
-    easingDuration={300}
-    easingFunction={null}
-    label="hours"
-    period="hours"
-    radix={10}
-  />
-  <CounterSegment
-    digitMap={Object {}}
-    digitWrapper={[Function]}
-    digits={
-      Array [
-        "0",
-        "0",
-      ]
-    }
-    direction="down"
-    easingDuration={300}
-    easingFunction={null}
-    label="minutes"
-    period="minutes"
-    radix={10}
-  />
-  <CounterSegment
-    digitMap={Object {}}
-    digitWrapper={[Function]}
-    digits={
-      Array [
-        "0",
-        "0",
-      ]
-    }
-    direction="down"
-    easingDuration={300}
-    easingFunction={null}
-    label="seconds"
-    period="seconds"
-    radix={10}
-  />
+  <div>
+    <CounterSegment
+      digitMap={Object {}}
+      digitWrapper={[Function]}
+      digits={
+        Array [
+          "0",
+          "0",
+        ]
+      }
+      direction="down"
+      easingDuration={300}
+      easingFunction={null}
+      label="days"
+      period="days"
+      radix={10}
+    />
+    <CounterSegmentSeparator />
+  </div>
+  <div>
+    <CounterSegment
+      digitMap={Object {}}
+      digitWrapper={[Function]}
+      digits={
+        Array [
+          "0",
+          "0",
+        ]
+      }
+      direction="down"
+      easingDuration={300}
+      easingFunction={null}
+      label="hours"
+      period="hours"
+      radix={10}
+    />
+    <CounterSegmentSeparator />
+  </div>
+  <div>
+    <CounterSegment
+      digitMap={Object {}}
+      digitWrapper={[Function]}
+      digits={
+        Array [
+          "0",
+          "0",
+        ]
+      }
+      direction="down"
+      easingDuration={300}
+      easingFunction={null}
+      label="minutes"
+      period="minutes"
+      radix={10}
+    />
+    <CounterSegmentSeparator />
+  </div>
+  <div>
+    <CounterSegment
+      digitMap={Object {}}
+      digitWrapper={[Function]}
+      digits={
+        Array [
+          "0",
+          "0",
+        ]
+      }
+      direction="down"
+      easingDuration={300}
+      easingFunction={null}
+      label="seconds"
+      period="seconds"
+      radix={10}
+    />
+  </div>
 </div>
 `;

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -3,6 +3,7 @@ import { shallow, mount } from 'enzyme'
 import { shallowToJson } from 'enzyme-to-json'
 import Counter from '../../src/'
 import CounterSegment from '../../src/CounterSegment'
+import CounterSegmentSeparator from '../../src/CounterSegmentSeparator'
 
 describe('initialization', function () {
   it('throws an error when options are provided incorrectly', function () {
@@ -265,6 +266,15 @@ describe('rendering', function () {
       expect(segments.at(3).props().label).toEqual('second')
     })
   })
+
+  test('separator', function () {
+    const component = shallow(<Counter seconds={10} separator=':' />)
+    const separators = component.find(CounterSegmentSeparator)
+    expect(separators.at(0).props().content).toEqual(':')
+    expect(separators.at(1).props().content).toEqual(':')
+    expect(separators.at(2).props().content).toEqual(':')
+    expect(separators.at(3).props().content).toEqual(undefined)
+  })
 })
 
 describe('state and props', function () {
@@ -320,6 +330,7 @@ describe('state and props', function () {
         syncTime radix={8} direction='up'
         easingFunction='myEasingFn' easingDuration={123}
         digitMap={{ '0': 'o' }} digitWrapper={digitWrapper}
+        separator=':'
       />
     )
     expect(component.props()).toEqual({
@@ -337,7 +348,8 @@ describe('state and props', function () {
       frozen: false,
       direction: 'up',
       digitMap: { '0': 'o' },
-      digitWrapper: digitWrapper
+      digitWrapper: digitWrapper,
+      separator: ':'
     })
   })
 })


### PR DESCRIPTION
Default counters have no separators between segments:

![2017-03-13 15 23 18](https://cloud.githubusercontent.com/assets/17192674/23854128/046784be-0801-11e7-8481-0989c61e7a8c.png)


With a separator:
```jsx
<Counter {...opts} separator=':' />
```
![2017-03-13 15 21 43](https://cloud.githubusercontent.com/assets/17192674/23854119/f745de98-0800-11e7-83fd-14964a12dacf.png)
