### PR TITLE
Move crucial styles to default stylesheet

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,11 +6,13 @@ module.exports = function (config) {
   config.set({
     browsers: browsers,
     singleRun: true,
-    basePath: 'test/acceptance',
     frameworks: ['jasmine'],
-    files: ['tests.js'],
+    files: [
+      'stylesheets/minimal.css',
+      'test/acceptance/tests.js'
+    ],
     preprocessors: {
-      'tests.js': ['webpack', 'sourcemap']
+      'test/acceptance/tests.js': ['webpack', 'sourcemap']
     },
     reporters: ['dots'],
     webpack: {

--- a/src/AnimatedCounterDigit.js
+++ b/src/AnimatedCounterDigit.js
@@ -131,8 +131,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
       transitionTimingFunction: this.props.easingFunction,
       transitionDuration: `${this.props.easingDuration}ms`,
       transitionProperty: 'transform',
-      willChange: 'transform',
-      display: 'inline-block'
+      willChange: 'transform'
     }
 
     return (

--- a/src/StaticCounterDigit.js
+++ b/src/StaticCounterDigit.js
@@ -20,7 +20,7 @@ class StaticCounterDigit extends AbstractCounterDigit {
    */
   render () {
     return (
-      <div className='rollex-digit' style={{ float: 'left' }}>
+      <div className='rollex-digit'>
         {this.decorateDigit(this.props.digit)}
       </div>
     )

--- a/stylesheets/minimal.css
+++ b/stylesheets/minimal.css
@@ -1,0 +1,7 @@
+.rollex-static .rollex-digit {
+  float: left;
+}
+
+.rollex-animated .rollex-digit {
+  display: inline-block;
+}

--- a/test/acceptance/support/helpers.js
+++ b/test/acceptance/support/helpers.js
@@ -9,8 +9,9 @@ export function bootstrapDOM () {
 }
 
 export function clearDOM () {
-  ReactDOM.unmountComponentAtNode(document.getElementById('root'))
-  document.body.innerHTML = ''
+  const root = document.getElementById('root')
+  ReactDOM.unmountComponentAtNode(root)
+  root.remove()
 }
 
 export function render (component) {

--- a/test/unit/StaticCounterDigit.test.js
+++ b/test/unit/StaticCounterDigit.test.js
@@ -7,7 +7,7 @@ it('decorates the digit', function () {
     digitWrapper: (digit) => <a href='#'>{digit}</a>
   })
   expect(componentWithWrapper.html()).toBe(
-    '<div class="rollex-digit" style="float:left;"><a href="#">0</a></div>'
+    '<div class="rollex-digit"><a href="#">0</a></div>'
   )
 
   const componentWithWrapperAndMap = Builder.shallow({
@@ -18,6 +18,6 @@ it('decorates the digit', function () {
     digitWrapper: (digit) => <div>{digit}</div>
   })
   expect(componentWithWrapperAndMap.html()).toBe(
-    '<div class="rollex-digit" style="float:left;"><div>o</div></div>'
+    '<div class="rollex-digit"><div>o</div></div>'
   )
 })

--- a/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
+++ b/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
@@ -8,7 +8,6 @@ exports[`matches snapshot 1`] = `
     Object {
       "MsTransform": "translateY(0px)",
       "WebkitTransform": "translateY(0px)",
-      "display": "inline-block",
       "transform": "translateY(0px)",
       "transitionDuration": "300ms",
       "transitionProperty": "transform",


### PR DESCRIPTION
Styles like `display: inline-block` for animated counter and `float: left` for static counter are crucial for the counters working. However, these styles should be overridable via normal CSS by the user.

I've decided to decouple CSS from JS a little bit and leave only *absolutely required* styles (`transform`, `transition`, etc.) inside JavaScript. The `stylesheets/minimal.css` has the minimal CSS required for the counter to work performantly. In the future, we could add themes into this folder, which is suitable for this library IMO.