### PR TITLE
Remove inline "height" styles from the code

### DIFF
--- a/src/AbstractCounterDigit.js
+++ b/src/AbstractCounterDigit.js
@@ -7,14 +7,12 @@ const { objectOf, any, number, string, func } = React.PropTypes
 class AbstractCounterDigit extends React.Component {
   /**
    * @property {string} digit - digit to display
-   * @property {number} height - digit height in pixels
    * @property {number} radix
    * @property {Object} digitMap - a map for transforming particular digits
    * @property {function(digit: number)} digitWrapper - a function for wrapping mapped digits
    */
   static propTypes = {
     digit: string.isRequired,
-    height: number.isRequired,
     radix: number.isRequired,
     digitMap: objectOf(any).isRequired,
     digitWrapper: func.isRequired

--- a/src/AnimatedCounterDigit.js
+++ b/src/AnimatedCounterDigit.js
@@ -87,7 +87,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
    */
   buildDigitDiv (digit, key) {
     return (
-      <div key={key || digit} className='rollex-digit-lane-label' style={{ height: this.props.height }}>
+      <div key={key || digit} className='rollex-digit-lane-label'>
         {this.decorateDigit(digit)}
       </div>
     )

--- a/src/AnimatedCounterDigit.js
+++ b/src/AnimatedCounterDigit.js
@@ -44,6 +44,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   constructor (props) {
     super(props)
 
+    // e.x.: 0..9 and another 0 => 9+2 = 11 digits total (see reset method)
     const singleDigitHeight = 100 / (this.props.maxValue + 2)
     const upperZeroPosition = -singleDigitHeight * (this.props.radix - this.props.maxValue - 1)
     const lowerZeroPosition = -singleDigitHeight * this.props.radix

--- a/src/AnimatedCounterDigit.js
+++ b/src/AnimatedCounterDigit.js
@@ -17,7 +17,6 @@ function forceReflow (element) {
  * @example
  * <AnimatedCounterDigit
  *   digit='5'
- *   height={18}
  *   radix={10}
  *   direction='down'
  *   digitMap={{}}
@@ -45,8 +44,9 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   constructor (props) {
     super(props)
 
-    const upperZeroPosition = -this.props.height * (this.props.radix - this.props.maxValue - 1)
-    const lowerZeroPosition = -this.props.height * this.props.radix
+    const singleDigitHeight = 100 / (this.props.maxValue + 2)
+    const upperZeroPosition = -singleDigitHeight * (this.props.radix - this.props.maxValue - 1)
+    const lowerZeroPosition = -singleDigitHeight * this.props.radix
     const initialZeroPosition = (this.props.direction === 'down')
       ? lowerZeroPosition : upperZeroPosition
     const finalZeroPosition = (this.props.direction === 'down')
@@ -54,7 +54,9 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
 
     this.state = {
       initialZeroPosition,
-      finalZeroPosition
+      finalZeroPosition,
+      singleDigitHeight,
+      digitLane: this.buildDigitLane()
     }
   }
 
@@ -70,7 +72,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
   reset = (event) => {
     if (this.props.digit === '0') {
       event.target.style.transitionProperty = 'none'
-      event.target.style.transform = `translateY(${this.state.initialZeroPosition}px)`
+      event.target.style.transform = `translateY(${this.state.initialZeroPosition}%)`
       forceReflow(event.target)
       event.target.style.transitionProperty = ''
     }
@@ -97,12 +99,12 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
    * @return {ReactElement[]}
    */
   buildDigitLane () {
-    var digitDivs = []
+    var digitLane = []
     for (let i = 0; i <= this.props.maxValue; i++) {
-      digitDivs.push(this.buildDigitDiv(i))
+      digitLane.push(this.buildDigitDiv(i))
     }
-    digitDivs.push(this.buildDigitDiv(0, this.props.radix + 1))
-    return digitDivs
+    digitLane.push(this.buildDigitDiv(0, this.props.radix + 1))
+    return digitLane
   }
 
   /**
@@ -114,7 +116,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
     if (digitIndex === 0) {
       return this.state.finalZeroPosition
     } else {
-      return -this.props.height * (digitIndex + (this.props.radix - this.props.maxValue - 1))
+      return -this.state.singleDigitHeight * (digitIndex + (this.props.radix - this.props.maxValue - 1))
     }
   }
 
@@ -123,7 +125,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
    * @return {ReactElement} digit
    */
   render () {
-    const transform = `translateY(${this.getDigitPositionY()}px)`
+    const transform = `translateY(${this.getDigitPositionY()}%)`
     const style = {
       transform: transform,
       WebkitTransform: transform,
@@ -136,7 +138,7 @@ class AnimatedCounterDigit extends AbstractCounterDigit {
 
     return (
       <div className='rollex-digit' onTransitionEnd={this.reset} style={style}>
-        {this.buildDigitLane()}
+        {this.state.digitLane}
       </div>
     )
   }

--- a/src/CounterSegment.js
+++ b/src/CounterSegment.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import ReactDOMServer from 'react-dom/server'
 import AnimatedCounterDigit from './AnimatedCounterDigit'
 import StaticCounterDigit from './StaticCounterDigit'
 const { arrayOf, object, number, string, func } = React.PropTypes
@@ -53,30 +52,6 @@ class CounterSegment extends React.Component {
   }
 
   /**
-   * constructor
-   * @param {Object} props
-   */
-  constructor (props) {
-    super(props)
-
-    /**
-     * Calculates height of a single digit.
-     */
-    const testDigit = document.createElement('div')
-    testDigit.innerHTML = ReactDOMServer.renderToString(this.props.digitWrapper('0'))
-    document.body.appendChild(testDigit)
-
-    /**
-     * @type {Object}
-     * @property {number} digitHeight - height of a single digit
-     */
-    this.state = {
-      digitHeight: testDigit.clientHeight
-    }
-    testDigit.remove()
-  }
-
-  /**
    * OPTIMIZE: this probably shouldn't be done in buildDigits. Perhaps we could perform calculations
    * for each possible index it in the constructor, but only for animated counters.
    *
@@ -112,7 +87,6 @@ class CounterSegment extends React.Component {
             direction={this.props.direction}
             easingFunction={this.props.easingFunction}
             easingDuration={this.props.easingDuration}
-            height={this.state.digitHeight}
             digitMap={this.props.digitMap}
             digitWrapper={this.props.digitWrapper}
           />
@@ -123,7 +97,6 @@ class CounterSegment extends React.Component {
             key={index}
             digit={digit}
             radix={this.props.radix}
-            height={this.state.digitHeight}
             digitMap={this.props.digitMap}
             digitWrapper={this.props.digitWrapper}
           />
@@ -137,13 +110,9 @@ class CounterSegment extends React.Component {
    * @return {ReactElement} counter segment
    */
   render () {
-    const style = {
-      overflow: 'hidden',
-      height: `${this.state.digitHeight}px`
-    }
     return (
       <div className='rollex-segment'>
-        <div className='rollex-digits' style={style}>
+        <div className='rollex-digits' style={{ overflow: 'hidden' }}>
           {this.buildDigits()}
         </div>
         <div className='rollex-label'>

--- a/src/StaticCounterDigit.js
+++ b/src/StaticCounterDigit.js
@@ -7,7 +7,6 @@ import AbstractCounterDigit from './AbstractCounterDigit'
  * @example
  * <StaticCounterDigit
  *   digit='5'
- *   height={18}
  *   radix={10}
  *   digitMap={{}}
  *   digitWrapper={(digit) => digit}

--- a/stylesheets/minimal.css
+++ b/stylesheets/minimal.css
@@ -5,3 +5,11 @@
 .rollex-animated .rollex-digit {
   display: inline-block;
 }
+
+.rollex-animated .rollex-digit-lane-label {
+  height: 18px;
+}
+
+.rollex-animated .rollex-digits {
+  height: 18px;
+}

--- a/test/acceptance/animated.test.js
+++ b/test/acceptance/animated.test.js
@@ -143,16 +143,8 @@ describe('digit map and digit wrapper', function () {
 })
 
 describe('radix', function () {
-  /**
-   * Radix is important here: digit height is calculated as a percentage.
-   * The formula is: (100 / (maxValue + 2)).
-   * Here, 9 is chosen because percentages for the two digits will be "12.5" and "10".
-   * The problem is in isVisible() function used in the custom matcher.
-   * Even though both Chrome and Firefox display digits normally, the function goes mad when it
-   * meets crazy percentages like 12.22222 (for radix 8, for example).
-   */
   it('displays numbers in given radix', function () {
-    const component = renderAnimatedTenSecondCounter({ radix: 9 })
-    expect(component).toDisplayDigits('11')
+    const component = renderAnimatedTenSecondCounter({ radix: 8 })
+    expect(component).toDisplayDigits('12')
   })
 })

--- a/test/acceptance/animated.test.js
+++ b/test/acceptance/animated.test.js
@@ -143,8 +143,16 @@ describe('digit map and digit wrapper', function () {
 })
 
 describe('radix', function () {
+  /**
+   * Radix is important here: digit height is calculated as a percentage.
+   * The formula is: (100 / (maxValue + 2)).
+   * Here, 9 is chosen because percentages for the two digits will be "12.5" and "10".
+   * The problem is in isVisible() function used in the custom matcher.
+   * Even though both Chrome and Firefox display digits normally, the function goes mad when it
+   * meets crazy percentages like 12.22222 (for radix 8, for example).
+   */
   it('displays numbers in given radix', function () {
-    const component = renderAnimatedTenSecondCounter({ radix: 8 })
-    expect(component).toDisplayDigits('12')
+    const component = renderAnimatedTenSecondCounter({ radix: 9 })
+    expect(component).toDisplayDigits('11')
   })
 })

--- a/test/acceptance/support/matchers.js
+++ b/test/acceptance/support/matchers.js
@@ -68,23 +68,26 @@ function getChildrenTextContents (object, selector, onlyVisible = false) {
  * @return {boolean} visible
  */
 function isVisible (element) {
-  if (element.offsetWidth === 0 || element.offsetHeight === 0) return false
-
-  const height = document.documentElement.clientHeight
-  const rects = element.getClientRects()
-
-  function onTop (rect) {
-    for (let x = Math.floor(rect.left); x <= Math.ceil(rect.right); x++) {
-      for (let y = Math.floor(rect.top); y <= Math.ceil(rect.bottom); y++) {
-        if (document.elementFromPoint(x, y) === element) return true
-      }
-    }
+  // Does element have non-zero dimensions?
+  if (element.offsetWidth + element.offsetHeight + element.getBoundingClientRect().height +
+    element.getBoundingClientRect().width === 0) {
     return false
   }
 
-  for (let rect of rects) {
-    const inViewport = rect.top > 0 ? rect.top <= height : (rect.bottom > 0 && rect.bottom <= height)
-    if (inViewport && onTop(rect)) return true
+  // Is the element on the screen?
+  const elementCenter = {
+    x: element.getBoundingClientRect().left + (element.offsetWidth / 2),
+    y: element.getBoundingClientRect().top + (element.offsetHeight / 2)
   }
+  if (elementCenter.x < 0) return false
+  if (elementCenter.x > (document.documentElement.clientWidth || window.innerWidth)) return false
+  if (elementCenter.y < 0) return false
+  if (elementCenter.y > (document.documentElement.clientHeight || window.innerHeight)) return false
+
+  // Try to "hit" our element while traversing its parents
+  let pointContainer = document.elementFromPoint(elementCenter.x, elementCenter.y)
+  do {
+    if (pointContainer === element) return true
+  } while (pointContainer = pointContainer.parentNode) // eslint-disable-line no-cond-assign
   return false
 }

--- a/test/unit/AnimatedCounterDigit.test.js
+++ b/test/unit/AnimatedCounterDigit.test.js
@@ -12,30 +12,6 @@ it('limits the value to maxValue', function () {
   expect(component.find('.rollex-digit-lane-label').length).toBe(7)
 })
 
-it('sets correct initial zero position', function () {
-  const downComponent = Builder.shallow({ direction: 'down', height: 1 })
-  expect(downComponent.state().initialZeroPosition).toBe(-10)
-  const downComponentWithMax = Builder.shallow({ direction: 'down', maxValue: 2, height: 1 })
-  expect(downComponentWithMax.state().initialZeroPosition).toBe(-10)
-
-  const upComponent = Builder.shallow({ direction: 'up', height: 1 })
-  expect(upComponent.state().initialZeroPosition).toBe(0)
-  const upComponentWithMax = Builder.shallow({ direction: 'up', maxValue: 2, height: 1 })
-  expect(upComponentWithMax.state().initialZeroPosition).toBe(-7)
-})
-
-it('sets correct final zero position', function () {
-  const downComponent = Builder.shallow({ direction: 'down', height: 1 })
-  expect(downComponent.state().finalZeroPosition).toBe(0)
-  const downComponentWithMax = Builder.shallow({ direction: 'down', maxValue: 2, height: 1 })
-  expect(downComponentWithMax.state().finalZeroPosition).toBe(-7)
-
-  const upComponent = Builder.shallow({ direction: 'up', height: 1 })
-  expect(upComponent.state().finalZeroPosition).toBe(-10)
-  const upComponentWithMax = Builder.shallow({ direction: 'up', maxValue: 2, height: 1 })
-  expect(upComponentWithMax.state().finalZeroPosition).toBe(-10)
-})
-
 test('reset() is being called on transition end', function () {
   const component = Builder.mount()
   component.instance().reset = jest.genMockFunction()

--- a/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
+++ b/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
@@ -18,11 +18,6 @@ exports[`matches snapshot 1`] = `
 >
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       0
@@ -30,11 +25,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       1
@@ -42,11 +32,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       2
@@ -54,11 +39,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       3
@@ -66,11 +46,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       4
@@ -78,11 +53,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       5
@@ -90,11 +60,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       6
@@ -102,11 +67,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       7
@@ -114,11 +74,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       8
@@ -126,11 +81,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       9
@@ -138,11 +88,6 @@ exports[`matches snapshot 1`] = `
   </div>
   <div
     className="rollex-digit-lane-label"
-    style={
-      Object {
-        "height": undefined,
-      }
-    }
   >
     <span>
       0

--- a/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
+++ b/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
@@ -6,9 +6,9 @@ exports[`matches snapshot 1`] = `
   onTransitionEnd={[Function]}
   style={
     Object {
-      "MsTransform": "translateY(0px)",
-      "WebkitTransform": "translateY(0px)",
-      "transform": "translateY(0px)",
+      "MsTransform": "translateY(0%)",
+      "WebkitTransform": "translateY(0%)",
+      "transform": "translateY(0%)",
       "transitionDuration": "300ms",
       "transitionProperty": "transform",
       "transitionTimingFunction": "ease-in",
@@ -20,7 +20,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -32,7 +32,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -44,7 +44,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -56,7 +56,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -68,7 +68,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -80,7 +80,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -92,7 +92,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -104,7 +104,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -116,7 +116,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -128,7 +128,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >
@@ -140,7 +140,7 @@ exports[`matches snapshot 1`] = `
     className="rollex-digit-lane-label"
     style={
       Object {
-        "height": 18,
+        "height": undefined,
       }
     }
   >

--- a/test/unit/__snapshots__/CounterSegment.test.js.snap
+++ b/test/unit/__snapshots__/CounterSegment.test.js.snap
@@ -8,7 +8,6 @@ exports[`snaphots matches snapshots 1`] = `
     className="rollex-digits"
     style={
       Object {
-        "height": "0px",
         "overflow": "hidden",
       }
     }
@@ -17,14 +16,12 @@ exports[`snaphots matches snapshots 1`] = `
       digit="0"
       digitMap={Object {}}
       digitWrapper={[Function]}
-      height={0}
       radix={10}
     />
     <StaticCounterDigit
       digit="0"
       digitMap={Object {}}
       digitWrapper={[Function]}
-      height={0}
       radix={10}
     />
   </div>
@@ -44,7 +41,6 @@ exports[`snaphots matches snapshots 2`] = `
     className="rollex-digits"
     style={
       Object {
-        "height": "0px",
         "overflow": "hidden",
       }
     }
@@ -56,7 +52,6 @@ exports[`snaphots matches snapshots 2`] = `
       direction="down"
       easingDuration={300}
       easingFunction="ease-in"
-      height={0}
       maxValue={5}
       radix={10}
     />
@@ -67,7 +62,6 @@ exports[`snaphots matches snapshots 2`] = `
       direction="down"
       easingDuration={300}
       easingFunction="ease-in"
-      height={0}
       maxValue={9}
       radix={10}
     />

--- a/test/unit/support/builders.js
+++ b/test/unit/support/builders.js
@@ -36,14 +36,13 @@ export class CounterSegmentBuilder extends AbstractBuilder {
 export class StaticCounterDigitBuilder extends AbstractBuilder {
   static build = function ({
     digit = '0',
-    height = 18,
     radix = 10,
     digitMap = {},
     digitWrapper = (digit) => <span>{digit}</span>
   } = {}) {
     return React.createElement(
       StaticCounterDigit,
-      { digit, height, radix, digitMap, digitWrapper }
+      { digit, radix, digitMap, digitWrapper }
     )
   }
 }
@@ -51,7 +50,6 @@ export class StaticCounterDigitBuilder extends AbstractBuilder {
 export class AnimatedCounterDigitBuilder extends AbstractBuilder {
   static build = function ({
     digit = '0',
-    height = 18,
     radix = 10,
     direction = 'down',
     digitMap = {},
@@ -62,7 +60,7 @@ export class AnimatedCounterDigitBuilder extends AbstractBuilder {
   } = {}) {
     return React.createElement(
       AnimatedCounterDigit,
-      { digit, height, radix, direction, digitMap, digitWrapper, maxValue, easingFunction, easingDuration }
+      { digit, radix, direction, digitMap, digitWrapper, maxValue, easingFunction, easingDuration }
     )
   }
 }


### PR DESCRIPTION
This is related mostly to animated counters.

**Problem:**
Rollex tried to calculate the height of a single digit to then hardcode `style: "height: <height>px"` into some elements to ensure consistency and calculate transforms (`translateY`) later. This created some problems with inline styles (needless to say). Also, the way of calculating the height of a digit was a big question in itself. It clearly would create a big mess on production websites (as we found out today trying to embed the counter into one).

**Solution:**
Leave this to CSS and use percentage transforms to animate the counter. This way, we don't have to come up with hacks. We also don't have to use `ReactDOMServer`, which is a weird thing to do in a library anyway.