### PR TITLE
When given a negative time difference, treat it as zero

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,10 +11,8 @@ if (process.env.TRAVIS) {
     process.exit(1)
   }
   browsers = Object.keys(sauceLaunchers)
-} else if (process.platform === 'darwin') {
-  browsers = ['Chrome', 'Firefox', 'Safari']
 } else {
-  browsers = ['Chrome', 'Firefox']
+  browsers = ['Chrome']
 }
 
 module.exports = function (config) {

--- a/src/helpers/counterBuilder.js
+++ b/src/helpers/counterBuilder.js
@@ -23,13 +23,9 @@ export default class CounterBuilder {
     if (props.seconds !== undefined) {
       if (props.to !== undefined || props.from !== undefined) {
         throw new Error('cannot use "to" and "from" with "seconds"')
-      } else if (props.seconds < 0) {
-        throw new Error('"seconds" must be greater than or equal to zero')
       }
     } else if (props.to === undefined) {
       throw new Error('provide either "seconds" or "to"')
-    } else if (props.to < props.from) {
-      throw new Error('"to" must be bigger than "from"')
     }
     if (props.digits !== undefined && props.digits < 0) {
       throw new Error('"digits" must not be negative')
@@ -83,9 +79,12 @@ export default class CounterBuilder {
   buildTimeProps () {
     const startTime = new Date().getTime()
     const from = (this.props.from === undefined) ? startTime : this.props.from
-    const timeDiff = (this.props.seconds === undefined)
+
+    var timeDiff = (this.props.seconds === undefined)
       ? (this.props.to - from)
       : (this.props.seconds * 1000)
+    if (timeDiff < 0) timeDiff = 0
+
     this.state = {
       ...this.state,
       startTime,

--- a/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
+++ b/test/unit/__snapshots__/AnimatedCounterDigit.test.js.snap
@@ -6,9 +6,9 @@ exports[`matches snapshot 1`] = `
   onTransitionEnd={[Function]}
   style={
     Object {
-      "MsTransform": "translate3D(0, 0%, 0)",
-      "WebkitTransform": "translate3D(0, 0%, 0)",
-      "transform": "translate3D(0, 0%, 0)",
+      "MsTransform": "translate3D(0, -9.090909090909092%, 0)",
+      "WebkitTransform": "translate3D(0, -9.090909090909092%, 0)",
+      "transform": "translate3D(0, -9.090909090909092%, 0)",
       "transitionDuration": "300ms",
       "transitionProperty": "transform",
       "transitionTimingFunction": "ease-in",

--- a/test/unit/counter/initialization.test.js
+++ b/test/unit/counter/initialization.test.js
@@ -25,12 +25,6 @@ it('throws an error when options are provided incorrectly', function () {
     () => shallow(<Counter to={0} seconds={2} />)
   ).toThrowError('cannot use "to" and "from" with "seconds"')
   expect(
-    () => shallow(<Counter from={1} to={0} />)
-  ).toThrowError('"to" must be bigger than "from"')
-  expect(
-    () => shallow(<Counter seconds={-1} />)
-  ).toThrowError('"seconds" must be greater than or equal to zero')
-  expect(
     () => shallow(<Counter seconds={0} digits={-1} />)
   ).toThrowError('"digits" must not be negative')
   expect(
@@ -63,7 +57,13 @@ it('initializes when options are correct', function () {
     () => shallow(<Counter from={0} to={1} />)
   ).not.toThrow()
   expect(
+    () => shallow(<Counter from={1} to={0} />)
+  ).not.toThrow()
+  expect(
     () => shallow(<Counter seconds={2} />)
+  ).not.toThrow()
+  expect(
+    () => shallow(<Counter seconds={-1} />)
   ).not.toThrow()
   expect(
     () => shallow(<Counter seconds={2} digits={0} />)

--- a/test/unit/counter/render.test.js
+++ b/test/unit/counter/render.test.js
@@ -38,6 +38,30 @@ describe('rendering', function () {
       ])
   })
 
+  describe('renders zeros when time diff is negative', function () {
+    test('from and to', function () {
+      const component = <Counter from={1000} to={0} />
+      expect(component)
+        .toHaveDigits([
+          ['0', '0'],
+          ['0', '0'],
+          ['0', '0'],
+          ['0', '0']
+        ])
+    })
+
+    test('seconds', function () {
+      const component = <Counter seconds={-10000} />
+      expect(component)
+        .toHaveDigits([
+          ['0', '0'],
+          ['0', '0'],
+          ['0', '0'],
+          ['0', '0']
+        ])
+    })
+  })
+
   it('works with "up" direction', function () {
     expect(<Counter from={0} to={to} direction='up' />)
       .toHaveDigits([

--- a/test/unit/counter/stateAndProps.test.js
+++ b/test/unit/counter/stateAndProps.test.js
@@ -80,4 +80,22 @@ describe('state and props', function () {
       separator: ':'
     })
   })
+
+  describe('sets timeDiff to zero when its negative', function () {
+    test('from and to', function () {
+      const component = mount(<Counter from={10000} to={0} />)
+      expect(component.state()).toMatchObject({
+        timeDiff: 0,
+        initialTimeDiff: 0
+      })
+    })
+
+    test('seconds', function () {
+      const component = mount(<Counter seconds={-10000} />)
+      expect(component.state()).toMatchObject({
+        timeDiff: 0,
+        initialTimeDiff: 0
+      })
+    })
+  })
 })

--- a/test/unit/support/builders.js
+++ b/test/unit/support/builders.js
@@ -49,7 +49,7 @@ export class StaticCounterDigitBuilder extends AbstractBuilder {
 
 export class AnimatedCounterDigitBuilder extends AbstractBuilder {
   static build = function ({
-    digit = '0',
+    digit = '1',
     radix = 10,
     direction = 'down',
     digitMap = {},


### PR DESCRIPTION
Right now, if you pass negative time difference to a counter, like this:
```jsx
<Rollex.Counter from={1000} to={0} />
// or
<Rollex.Counter seconds={-1000} />
```
The counter would throw an error. This would make sense if the user would pass properties to each counter by hand every time, but in real applications, negative time diffs might be normal. In this case, it's simply better to show zeroes, as in "countdown already ended".